### PR TITLE
Add utility to merge and deduplicate .bin training data files

### DIFF
--- a/script/merge_dedup_bins.py
+++ b/script/merge_dedup_bins.py
@@ -1,0 +1,49 @@
+import argparse
+
+RECORD_SIZE = 40
+SFEN_SIZE = 32
+
+def process_files(input_files, output_file):
+    seen_sfens = set()
+    total_records_read = 0
+    unique_records_written = 0
+
+    with open(output_file, 'wb') as f_out:
+        for input_path in input_files:
+            print(f"Processing input file: {input_path}")
+            try:
+                with open(input_path, 'rb') as f_in:
+                    while True:
+                        record = f_in.read(RECORD_SIZE)
+                        if not record:
+                            break  # End of file
+                        
+                        if len(record) < RECORD_SIZE:
+                            print(f"Warning: Malformed record in {input_path}. Expected {RECORD_SIZE} bytes, got {len(record)}. Skipping.")
+                            continue
+                        
+                        total_records_read += 1
+                        sfen_data = record[:SFEN_SIZE]
+                        
+                        if sfen_data not in seen_sfens:
+                            seen_sfens.add(sfen_data)
+                            f_out.write(record)
+                            unique_records_written += 1
+            except FileNotFoundError:
+                print(f"Error: Input file not found: {input_path}")
+            except Exception as e:
+                print(f"An error occurred while processing {input_path}: {e}")
+    
+    print("\n--- Summary ---")
+    print(f"Total records read: {total_records_read}")
+    print(f"Total unique records written: {unique_records_written}")
+    print(f"Output file: {output_file}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge and deduplicate records from binary files.")
+    parser.add_argument('input_files', nargs='+', help="Paths to input binary files.")
+    parser.add_argument('output_file', help="Path to the output binary file.")
+    
+    args = parser.parse_args()
+    
+    process_files(args.input_files, args.output_file)


### PR DESCRIPTION
This commit introduces a new Python script `script/merge_dedup_bins.py`. This tool allows you to merge multiple `.bin` training data files (assumed to be composed of 40-byte entries in the FSF/nodchip PackedSfenValue format) into a single output file.

The script intelligently removes duplicate entries by comparing the first 32 bytes (the SFEN/compressed position data) of each 40-byte record. It keeps the first occurrence of a unique SFEN and discards subsequent duplicates.

The tool includes command-line arguments for specifying input files and an output file, provides basic progress reporting, and handles file errors. This is useful for cleaning and combining datasets generated in batches or from different sources.