### PR TITLE
Add convert_epd command for data conversion

### DIFF
--- a/src/tools/convert.cpp
+++ b/src/tools/convert.cpp
@@ -498,6 +498,41 @@ namespace Stockfish::Tools
         std::cout << "all done" << std::endl;
     }
 
+    void convert_epd(
+        const vector<string>& filenames,
+        const string& output_file_name)
+    {
+        Position tpos;
+        std::ofstream ofs;
+        ofs.open(output_file_name, ios::app);
+        auto th = Threads.main();
+        for (auto filename : filenames) {
+            std::cout << "convert " << filename << " ... ";
+
+            // Convert packedsfenvalue to EPD format (FEN only)
+            std::fstream fs;
+            fs.open(filename, ios::in | ios::binary);
+            PackedSfenValue p;
+            while (true)
+            {
+                if (fs.read((char*)&p, sizeof(PackedSfenValue))) {
+                    StateInfo si;
+                    tpos.set_from_packed_sfen(p.sfen, &si, th);
+
+                    // write only FEN (EPD format)
+                    ofs << tpos.fen() << std::endl;
+                }
+                else {
+                    break;
+                }
+            }
+            fs.close();
+            std::cout << "done" << std::endl;
+        }
+        ofs.close();
+        std::cout << "all done" << std::endl;
+    }
+
     void convert(istringstream&)
     {
         std::cerr << "ERROR: The 'convert' command has been removed. Please use 'convert_bin' or 'convert_plain' instead.\n";
@@ -713,5 +748,51 @@ namespace Stockfish::Tools
 
         cout << "convert_plain.." << endl;
         convert_plain(filenames, output_file_name);
+    }
+
+    void convert_epd(std::istringstream& is)
+    {
+        std::vector<std::string> filenames;
+
+        string base_dir;
+        string target_dir;
+
+        string output_file_name = "shuffled_sfen.bin";
+
+        while (true)
+        {
+            string option;
+            is >> option;
+
+            if (option == "")
+                break;
+
+            if (option == "targetdir") is >> target_dir;
+            else if (option == "targetfile")
+            {
+                std::string filename;
+                is >> filename;
+                filenames.push_back(filename);
+            }
+
+            else if (option == "basedir")   is >> base_dir;
+
+            else if (option == "output_file_name") is >> output_file_name;
+            else
+            {
+                cout << "Unknown option: " << option << ". Ignoring.\n";
+            }
+        }
+
+        if (!target_dir.empty())
+        {
+            append_files_from_dir(filenames, base_dir, target_dir);
+        }
+        rebase_files(filenames, base_dir);
+
+        Eval::NNUE::init();
+
+        cout << "convert_epd.." << endl;
+        convert_epd(filenames, output_file_name);
     }
 }

--- a/src/tools/convert.h
+++ b/src/tools/convert.h
@@ -13,6 +13,8 @@ namespace Stockfish::Tools {
     void convert_bin(std::istringstream& is);
 
     void convert_plain(std::istringstream& is);
+
+    void convert_epd(std::istringstream& is);
 }
 
 #endif

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -579,6 +579,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "validate_training_data") Tools::validate_training_data(is);
       else if (token == "convert_bin") Tools::convert_bin(is);
       else if (token == "convert_plain") Tools::convert_plain(is);
+      else if (token == "convert_epd") Tools::convert_epd(is);
       else if (token == "convert_bin_from_pgn_extract") Tools::convert_bin_from_pgn_extract(is);
       else if (token == "transform") Tools::transform(is);
       else if (token == "gather_statistics") Tools::Stats::gather_statistics(is);


### PR DESCRIPTION
This commit adds a new `convert_epd` command that converts binary training data to EPD (Extended Position Description) format. The EPD format contains only FEN strings, with one position per line.

This is similar to the existing `convert_plain` command, but instead of outputting all position metadata (move, score, ply, result), it outputs only the FEN representation of each position.

Usage:
  convert_epd targetfile <file.bin> output_file_name <output.epd>

Changes:
- Added convert_epd() core function in src/tools/convert.cpp
- Added convert_epd() wrapper function in src/tools/convert.cpp
- Added convert_epd() declaration in src/tools/convert.h
- Added command routing in src/uci.cpp