### PR TITLE
Add EPD as direct puzzle output format

### DIFF
--- a/docs/generate_puzzles.md
+++ b/docs/generate_puzzles.md
@@ -76,6 +76,6 @@ Currently the following options are available:
 
 `filter_promotions` - either 0 or 1. If 1 then positions where the best move is a promotion will be filtered out. Default: 0.
 
-`data_format` - format of the puzzle data to use. Only `bin` is supported. Default: `bin`.
+`data_format` - format of the puzzle data to use. Supported formats are `bin` (binary PackedSfenValue format) and `epd` (Extended Position Description, FEN strings). Default: `bin`.
 
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.

--- a/docs/generate_puzzles.md
+++ b/docs/generate_puzzles.md
@@ -76,6 +76,6 @@ Currently the following options are available:
 
 `filter_promotions` - either 0 or 1. If 1 then positions where the best move is a promotion will be filtered out. Default: 0.
 
-`data_format` - format of the puzzle data to use. Supported formats are `bin` (binary PackedSfenValue format) and `epd` (Extended Position Description, FEN strings). Default: `bin`.
+`data_format` - format of the puzzle data to use. Supported formats are `bin` (binary PackedSfenValue format) and `epd` (Extended Position Description, FEN strings). Default: `epd`.
 
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,6 +55,7 @@ SRCS = benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp main.cpp 
 	nnue/features/half_ka_v2.cpp \
 	tools/validate_training_data.cpp \
 	tools/sfen_packer.cpp \
+	tools/sfen_stream.cpp \
 	tools/training_data_generator.cpp \
 	tools/training_data_generator_nonpv.cpp \
 	tools/puzzle_generator.cpp \

--- a/src/tools/puzzle_generator.cpp
+++ b/src/tools/puzzle_generator.cpp
@@ -95,7 +95,7 @@ namespace Stockfish::Tools
 
             std::string output_file_name = "puzzles";
 
-            SfenOutputType sfen_format = SfenOutputType::Bin;
+            SfenOutputType sfen_format = SfenOutputType::Epd;
 
             std::string seed;
 
@@ -783,7 +783,7 @@ namespace Stockfish::Tools
 
         // Add a random number to the end of the file name.
         bool random_file_name = false;
-        std::string sfen_format = "bin";
+        std::string sfen_format = "epd";
 
         string token;
         while (true)

--- a/src/tools/puzzle_generator.cpp
+++ b/src/tools/puzzle_generator.cpp
@@ -888,6 +888,8 @@ namespace Stockfish::Tools
         {
             if (sfen_format == "bin")
                 params.sfen_format = SfenOutputType::Bin;
+            else if (sfen_format == "epd")
+                params.sfen_format = SfenOutputType::Epd;
             else
                 cout << "WARNING: Unknown sfen format `" << sfen_format << "`. Using bin\n";
         }

--- a/src/tools/sfen_stream.cpp
+++ b/src/tools/sfen_stream.cpp
@@ -1,0 +1,30 @@
+#include "sfen_stream.h"
+#include "position.h"
+#include "thread.h"
+
+namespace Stockfish::Tools {
+
+    EpdSfenOutputStream::EpdSfenOutputStream(std::string filename)
+        : m_stream(filename_with_extension(filename, extension), openmode)
+    {
+    }
+
+    void EpdSfenOutputStream::write(const PSVector& sfens)
+    {
+        // We need a Position and Thread to unpack the sfens
+        // Get the main thread for unpacking positions
+        auto th = Threads.main();
+        Position pos;
+        StateInfo si;
+
+        for (const auto& psv : sfens)
+        {
+            // Unpack the sfen to get the position
+            set_from_packed_sfen(pos, psv.sfen, &si, th);
+
+            // Write the FEN string followed by a newline
+            m_stream << pos.fen() << '\n';
+        }
+    }
+
+}

--- a/src/tools/sfen_stream.h
+++ b/src/tools/sfen_stream.h
@@ -2,6 +2,7 @@
 #define _SFEN_STREAM_H_
 
 #include "packed_sfen.h"
+#include "sfen_packer.h"
 
 #include <cassert>
 #include <optional>
@@ -13,7 +14,8 @@ namespace Stockfish::Tools {
 
     enum struct SfenOutputType
     {
-        Bin
+        Bin,
+        Epd
     };
 
     static bool ends_with(const std::string& lhs, const std::string& end)
@@ -111,6 +113,21 @@ namespace Stockfish::Tools {
         std::fstream m_stream;
     };
 
+    struct EpdSfenOutputStream : BasicSfenOutputStream
+    {
+        static constexpr auto openmode = std::ios::out | std::ios::app;
+        static inline const std::string extension = "epd";
+
+        EpdSfenOutputStream(std::string filename);
+
+        void write(const PSVector& sfens) override;
+
+        ~EpdSfenOutputStream() override {}
+
+    private:
+        std::fstream m_stream;
+    };
+
     inline std::unique_ptr<BasicSfenInputStream> open_sfen_input_file(const std::string& filename)
     {
         if (has_extension(filename, BinSfenInputStream::extension))
@@ -125,6 +142,8 @@ namespace Stockfish::Tools {
         {
             case SfenOutputType::Bin:
                 return std::make_unique<BinSfenOutputStream>(filename);
+            case SfenOutputType::Epd:
+                return std::make_unique<EpdSfenOutputStream>(filename);
         }
 
         assert(false);


### PR DESCRIPTION
- Add EPD enum value to SfenOutputType
- Create EpdSfenOutputStream class for writing FEN strings
- Implement thread-safe EPD output using existing SfenWriter infrastructure
- Update puzzle_generator to accept 'epd' as data_format option
- Update documentation to reflect EPD format support
- Add sfen_stream.cpp to Makefile

The EPD output writes positions as FEN strings (one per line) instead of binary PackedSfenValue format. Thread-safety is ensured through the existing SfenWriter mutex-based synchronization.