### PR TITLE
Ensure the upstream sync

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -40,7 +40,13 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
-      # Step 2: Sync upstream changes
+      # Step 2: Configure ours merge driver
+      - name: Configure ours merge driver
+        run: |
+          git config merge.ours.driver true
+          git config merge.ours.name "Keep ours merge driver"
+
+      # Step 3: Sync upstream changes
       - name: Sync upstream changes
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
@@ -52,7 +58,7 @@ jobs:
           test_mode: ${{ inputs.test_mode || false }}
           shallow_since: ${{ inputs.shallow_since || '1 month ago' }}
 
-      # Step 3: Display sync status
+      # Step 4: Display sync status
       - name: New commits found
         if: steps.sync.outputs.has_new_commits == 'true'
         run: echo "New commits were found and synced from upstream."


### PR DESCRIPTION
Configure the 'ours' merge driver before syncing upstream changes to ensure proper conflict resolution during automated syncs.